### PR TITLE
fixed temp precision issue

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -68,7 +68,7 @@ export function Main() {
                 <Sun size={48} className="mr-4" />
                 <div>
                   <p className="text-3xl font-bold">
-                    {weather?.main.temp.toString().slice(0, 4)}°C
+                    {weather?.main.temp.toFixed(2)}°C
                   </p>
                   <p>{weather?.weather[0].description}</p>
                 </div>


### PR DESCRIPTION
This update addresses a precision issue with the temperature display in our weather application. The original implementation used weather?.main.temp.toString().slice(0, 3), which often resulted in inaccurate temperature readings by truncating the temperature value to just the first three characters of the string.

With the fix, we now utilize weather?.main.temp.toFixed(2), ensuring that the temperature is rounded and displayed to two decimal places. This enhancement provides a more precise and reliable representation of the temperature, improving the overall user experience when checking weather conditions. The temperature will now appear in the format XX.XX°C, allowing for clearer and more accurate information.